### PR TITLE
Update setup-node action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         node: [20, 22]
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: npm


### PR DESCRIPTION
## What changed

- update `actions/setup-node` from v6 to v7 on current main

## Why

Renovate PR #192 was created alongside the checkout v7 update. After #191 merged, GitHub could not rebase #192 because both branches touched the same workflow hunk. This replacement preserves checkout v7 and isolates the remaining action update.

## Validation

- `npm ci`
- `npm test`
- `npm audit --audit-level=high` (0 vulnerabilities)
- `git diff --check`

## Release boundary

CI-only change; no application or Pages deployment is performed.
